### PR TITLE
[Feat/#2] Next.js 15 Design Component 사용시 에러

### DIFF
--- a/packages/frieeren-components/.storybook/preview.tsx
+++ b/packages/frieeren-components/.storybook/preview.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import type { Preview } from "@storybook/react";
 import "../src/style/index.scss";
-import "../src/style/design-token/index.scss";
 
 const preview: Preview = {
   parameters: {

--- a/packages/frieeren-components/README.md
+++ b/packages/frieeren-components/README.md
@@ -1,0 +1,9 @@
+# @team-frieeren/components
+
+## 사용 예시
+
+```ts
+import { Button } from '@team-frieeren/components';
+import { Popup } from '@team-frieeren/components/client';
+import '@team-frieeren/components/styles';
+```

--- a/packages/frieeren-components/package.json
+++ b/packages/frieeren-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@team-frieeren/components",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -85,6 +85,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./client": {
+      "import": "./dist/client.js",
+      "types": "./dist/client.d.ts"
     },
     "./styles": "./dist/index.css"
   }

--- a/packages/frieeren-components/package.json
+++ b/packages/frieeren-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@team-frieeren/components",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/frieeren-components/package.json
+++ b/packages/frieeren-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@team-frieeren/components",
-  "version": "1.0.2",
+  "version": "1.0.5",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/frieeren-components/rollup.config.js
+++ b/packages/frieeren-components/rollup.config.js
@@ -42,6 +42,9 @@ export default [
         format: "es"
       }
     ],
-    plugins: commonPlugins
+    plugins: [
+      ...commonPlugins,
+      postcss({ inject: false }) // CSS는 index에서 한 번만 추출해서 사용
+    ]
   }
 ];

--- a/packages/frieeren-components/rollup.config.js
+++ b/packages/frieeren-components/rollup.config.js
@@ -4,27 +4,44 @@ import postcss from "rollup-plugin-postcss";
 import { typescriptPaths } from "rollup-plugin-typescript-paths";
 import svgr from "@svgr/rollup";
 
-export default {
-  input: "src/index.ts",
-  external: ["@radix-ui/react-popover"],
-  output: [
-    {
-      file: "dist/index.js",
-      format: "es"
-    }
-  ],
-  plugins: [
-    svgr({ icon: true }),
-    typescript({
-      tsconfig: "./tsconfig.json",
-      declarationDir: "./dist"
-    }),
-    babel({
-      babelHelpers: "bundled",
-      extensions: [".js", ".jsx", ".ts", ".tsx"],
-      presets: ["@babel/preset-env", "@babel/preset-react", "@babel/preset-typescript"]
-    }),
-    postcss({ extract: true, minifycss: true }),
-    typescriptPaths()
-  ]
-};
+const commonPlugins = [
+  svgr({ icon: true }),
+  typescript({
+    tsconfig: "./tsconfig.json",
+    declarationDir: "./dist"
+  }),
+  babel({
+    babelHelpers: "bundled",
+    extensions: [".js", ".jsx", ".ts", ".tsx"],
+    presets: ["@babel/preset-env", "@babel/preset-react", "@babel/preset-typescript"]
+  }),
+  typescriptPaths()
+];
+
+export default [
+  {
+    input: "src/index.ts",
+    external: ["@radix-ui/react-popover"],
+    output: [
+      {
+        file: "dist/index.js",
+        format: "es"
+      }
+    ],
+    plugins: [
+      ...commonPlugins,
+      postcss({ extract: true, minifycss: true }) // CSS는 index에서 한 번만 추출해서 사용
+    ]
+  },
+  {
+    input: "src/client.ts",
+    external: ["@radix-ui/react-popover"],
+    output: [
+      {
+        file: "dist/client.js",
+        format: "es"
+      }
+    ],
+    plugins: commonPlugins
+  }
+];

--- a/packages/frieeren-components/rollup.config.js
+++ b/packages/frieeren-components/rollup.config.js
@@ -30,7 +30,11 @@ export default [
     ],
     plugins: [
       ...commonPlugins,
-      postcss({ extract: true, minifycss: true }) // CSS는 index에서 한 번만 추출해서 사용
+      postcss({
+        inject: false,
+        extract: "index.css",
+        minimize: true
+      })
     ]
   },
   {
@@ -44,7 +48,11 @@ export default [
     ],
     plugins: [
       ...commonPlugins,
-      postcss({ inject: false }) // CSS는 index에서 한 번만 추출해서 사용
+      postcss({
+        inject: false,
+        extract: "index.css",
+        minimize: true
+      })
     ]
   }
 ];

--- a/packages/frieeren-components/src/client.ts
+++ b/packages/frieeren-components/src/client.ts
@@ -1,3 +1,5 @@
+import "./style/index.scss";
+
 export { useFunnel } from "./components/Funnel";
 export { safeLocalStorage, safeSessionStorage } from "./shared/storage";
 export { RouterProvider, useRouter } from "./hooks/useRouter";

--- a/packages/frieeren-components/src/client.ts
+++ b/packages/frieeren-components/src/client.ts
@@ -1,0 +1,5 @@
+export { useFunnel } from "./components/Funnel";
+export { safeLocalStorage, safeSessionStorage } from "./shared/storage";
+export { RouterProvider, useRouter } from "./hooks/useRouter";
+export { WindowRouter } from "./router/windowRouter";
+export { useToast, ToastProvider } from "./components/Toast";

--- a/packages/frieeren-components/src/client.ts
+++ b/packages/frieeren-components/src/client.ts
@@ -3,3 +3,5 @@ export { safeLocalStorage, safeSessionStorage } from "./shared/storage";
 export { RouterProvider, useRouter } from "./hooks/useRouter";
 export { WindowRouter } from "./router/windowRouter";
 export { useToast, ToastProvider } from "./components/Toast";
+export { Popup } from "./components/Popup";
+export { BottomSheet } from "./components/BottomSheet";

--- a/packages/frieeren-components/src/components/Input/Input.tsx
+++ b/packages/frieeren-components/src/components/Input/Input.tsx
@@ -1,7 +1,6 @@
 import { forwardRef, useState } from "react";
 import cx from "classnames";
 import { InputProps } from "./input.type";
-import "./Input.scss";
 import CloseIcon from "./assets/close.svg";
 import LinkIcon from "./assets/link.svg";
 

--- a/packages/frieeren-components/src/components/Popup/Popup.tsx
+++ b/packages/frieeren-components/src/components/Popup/Popup.tsx
@@ -1,7 +1,6 @@
 import { Dialog } from "radix-ui";
 import cx from "classnames";
 import { PopupProps } from "./Popup.type";
-import "./Popup.scss";
 
 export const Popup: React.FC<PopupProps> = props => {
   const { className, children, buttonLayoutType, container, title, description, onClose, ...rest } =

--- a/packages/frieeren-components/src/components/Tabs/TabsBase.tsx
+++ b/packages/frieeren-components/src/components/Tabs/TabsBase.tsx
@@ -1,5 +1,4 @@
 import * as TabsBase from "@radix-ui/react-tabs";
-import "./Tabs.scss";
 
 const Root = ({ ...props }: TabsBase.TabsProps) => {
   return <TabsBase.Root data-frieeren-component="Tabs" className="tabs" {...props} />;

--- a/packages/frieeren-components/src/components/Toggle/Toggle.tsx
+++ b/packages/frieeren-components/src/components/Toggle/Toggle.tsx
@@ -2,7 +2,6 @@ import { forwardRef } from "react";
 import { Switch } from "radix-ui";
 import cx from "classnames";
 import { ToggleProps } from "./Toggle.type";
-import "./Toggle.scss";
 
 export const Toggle = forwardRef<HTMLButtonElement, ToggleProps>(
   ({ className, states = "active", onChange }, ref) => {

--- a/packages/frieeren-components/src/index.ts
+++ b/packages/frieeren-components/src/index.ts
@@ -10,7 +10,5 @@ export { RadioGroup } from "./components/RadioGroup";
 export { Checkbox } from "./components/Checkbox";
 export { Toggle } from "./components/Toggle";
 export { Select } from "./components/Select";
-export { Popup } from "./components/Popup";
-export { BottomSheet } from "./components/BottomSheet";
 export { Input } from "./components/Input";
 export { Tabs } from "./components/Tabs";

--- a/packages/frieeren-components/src/index.ts
+++ b/packages/frieeren-components/src/index.ts
@@ -1,7 +1,5 @@
 import "./style/index.scss";
 
-export { useFunnel } from "./components/Funnel";
-
 export { Box } from "./components/layout/Box";
 export { Container } from "./components/layout/Container";
 export { Flex } from "./components/layout/Flex";
@@ -16,9 +14,3 @@ export { Popup } from "./components/Popup";
 export { BottomSheet } from "./components/BottomSheet";
 export { Input } from "./components/Input";
 export { Tabs } from "./components/Tabs";
-export { ToastProvider } from "./components/Toast";
-
-export { safeLocalStorage, safeSessionStorage } from "./shared/storage";
-export { RouterProvider, useRouter } from "./hooks/useRouter";
-export { WindowRouter } from "./router/windowRouter";
-export { useToast } from "./components/Toast";

--- a/packages/frieeren-components/src/style/index.scss
+++ b/packages/frieeren-components/src/style/index.scss
@@ -7,12 +7,14 @@
 @use "../components/layout/Grid/Grid.scss";
 @use "../components/Button/Button.scss";
 @use "../components/Text/Text.scss";
-@use "../components/BottomSheet/BottomSheet.scss";
 @use "../components/Dialog/Dialog.scss";
-@use "../components/Toast/Toast.scss";
 @use "../components/Popover/Popover.scss";
 @use "../components/Select/Select.scss";
 @use "../components/Toggle/Toggle.scss";
-@use "../components/Popup/Popup.scss";
 @use "../components/Input/Input.scss";
 @use "../components//Tabs/Tabs.scss";
+
+// client components
+@use "../components/BottomSheet/BottomSheet.scss";
+@use "../components/Toast/Toast.scss";
+@use "../components/Popup/Popup.scss";


### PR DESCRIPTION
## 📝 PR 설명
Server Side에서 React.createContext 이슈가 발생했습니다.
모든 export 컴포넌트들이 하나의 번들 파일로 빌드되면서, 서버에서도 안전한 컴포넌트(Box, Button 등)와 클라이언트 전용 컴포넌트(useToast, useRouter 등)가 함께 번들링되었습니다. 
이로 인해 React.createContext나 브라우저 API를 사용하는 클라이언트 전용 코드가 서버에서도 실행되려고 해서 에러가 발생했습니다.

<!-- PR 설명 -->

## 관련된 이슈 넘버
close #2 

<!-- close #1 -->

## ✅ 작업 목록
- [x] version(1.0.1) 업데이트 (https://www.npmjs.com/package/@team-frieeren/components?activeTab=versions)
- [x] 번들을 서버에서도 안전한 컴포넌트(index.js)와 클라이언트 전용 컴포넌트(client.js)로 분리하여 각각 다른 entry point로 빌드
- [x] style의 경우 전체를 index에서 관리하므로 한 번만 추출해서 같이 사용(rollup.cofig.js)
<!-- 이슈 작업한 내용 -->

## 📚 논의사항
제가 놓친 부분이 있거나 더 좋은 방향성은 공유 및 피드백 부탁드립니다.
- 클라이언트 전용 컴포넌트의 경우 @team-frieeren/components/client로 사용하는 방식으로 조치하였습니다. 
- 클라이언트 전용 컴포넌트로 써야하는 컴포넌트는 아래와 같습니다(window api, createContext) 서버에서도 대응가능하도록 조치여부는 협의가 필요할 것 같습니다.
  - Funnel
  - BrowserStorage
  - Router
  - Toast
<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC
- 로컬 패키지 테스트
```bash
# 라이브러리
$ pnpm build
$ pnpm pack

# 사용하는 프로젝트
$ pnpm add ./*.tgz
```
<img width="697" alt="스크린샷 2025-07-04 오전 12 11 36" src="https://github.com/user-attachments/assets/3a87e99a-549d-4dcf-a5aa-c441e6b8434a" />

<!-- Screenshot, References 기재 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a new entry point for client-related utilities and hooks, making it easier to import features such as storage helpers, routing, and toast notifications.
* **Refactor**
  * Updated the package build process to generate separate bundles for main and client entry points.
  * Adjusted exports to streamline and separate client-specific features from the main package entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->