### PR TITLE
[Feat/#10] 스토리북 sns button svg변환으로 인한 build error

### DIFF
--- a/packages/frieeren-components/src/components/Button/Button.stories.tsx
+++ b/packages/frieeren-components/src/components/Button/Button.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import Google from "./assets/google.svg?react";
-import Apple from "./assets/apple.svg?react";
-import Kakao from "./assets/kakao.svg?react";
+import Google from "./assets/google.svg";
+import Apple from "./assets/apple.svg";
+import Kakao from "./assets/kakao.svg";
 
 import { Button } from ".";
 import { Text } from "../Text";


### PR DESCRIPTION
## 📝 PR 설명
- Storybook에서 SVG 파일을 React 컴포넌트로 import할 때 `.svg?react` 구문이 정상적으로 로드되지 않는 문제 발생
- 메인 애플리케이션에서는 정상 작동하지만 Storybook 환경에서만 SVG import 실패
- .svg 방식으로 import하도록 ButtonSNS 경로 수정하여 해결하였습니다.
<!-- PR 설명 -->

## 관련된 이슈 넘버
close #10 
<!-- close #1 -->

## ✅ 작업 목록
- [x] SVG 파일이 포함된 컴포넌트 스토리가 정상적으로 렌더링되는지 확인
- [x] 기존 스토리들이 여전히 정상 작동하는지 확인
<!-- 이슈 작업한 내용 -->

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->
![스크린샷 2025-07-05 오후 10 59 39](https://github.com/user-attachments/assets/4cd71091-1194-4963-8f81-7e0216a87c9c)
