### PR TITLE
fix(@team-frieeren/components): add "use client" directive in client.ts

### DIFF
--- a/packages/frieeren-components/rollup.config.js
+++ b/packages/frieeren-components/rollup.config.js
@@ -10,16 +10,12 @@ import svgr from "@svgr/rollup";
 function preserveUseClient() {
   return {
     name: "preserve-use-client",
-    generateBundle(options, bundle) {
-      Object.keys(bundle).forEach(fileName => {
-        const chunk = bundle[fileName];
+    renderChunk(code, chunk) {
+      if (chunk.isEntry && !code.startsWith('"use client"')) {
+        return '"use client";\n' + code;
+      }
 
-        if (chunk.type === "chunk" && chunk.isEntry) {
-          if (!chunk.code.startsWith('"use client"')) {
-            chunk.code = '"use client";\n' + chunk.code;
-          }
-        }
-      });
+      return null;
     }
   };
 }

--- a/packages/frieeren-components/rollup.config.js
+++ b/packages/frieeren-components/rollup.config.js
@@ -4,6 +4,26 @@ import postcss from "rollup-plugin-postcss";
 import { typescriptPaths } from "rollup-plugin-typescript-paths";
 import svgr from "@svgr/rollup";
 
+/**
+ * @type {import('rollup').PluginImpl}
+ */
+function preserveUseClient() {
+  return {
+    name: "preserve-use-client",
+    generateBundle(options, bundle) {
+      Object.keys(bundle).forEach(fileName => {
+        const chunk = bundle[fileName];
+
+        if (chunk.type === "chunk" && chunk.isEntry) {
+          if (!chunk.code.startsWith('"use client"')) {
+            chunk.code = '"use client";\n' + chunk.code;
+          }
+        }
+      });
+    }
+  };
+}
+
 const commonPlugins = [
   svgr({ icon: true }),
   typescript({
@@ -48,6 +68,7 @@ export default [
     ],
     plugins: [
       ...commonPlugins,
+      preserveUseClient(),
       postcss({
         inject: false,
         extract: "index.css",


### PR DESCRIPTION
## 📝 PR 설명

rollup plugin 을 추가 합니다.
해당 plugin의 역할은 csr 전용 component export file인 client.ts 상단에
"use client" directive를 추가하는 역할을 수행합니다.

이와 같은 방식으로 1차적으로 아래 관련 이슈를 해결 할 수 있습니다.

<!-- PR 설명 -->

## 관련된 이슈 넘버
- #9 
- #15 
- #16 (2번 수정사항)
<!-- close #1 -->

close #9 
close #16
## ✅ 작업 목록
- add rollup plugin: preserve-use-client
<!-- 이슈 작업한 내용 -->

## 📚 논의사항
#16 이슈의 추가적인 자료로 추후 frieeren-component lib의 export 방향성에 따라 수정하면 좋을거 같습니다 :)
<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Improved the build process to ensure the "use client" directive is automatically added to relevant client bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->