### PR TITLE
refactor(@team-frieeren/components): Toast 사용성 개선

### DIFF
--- a/packages/frieeren-components/package.json
+++ b/packages/frieeren-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@team-frieeren/components",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/frieeren-components/src/components/Toast/ToastProvider.tsx
+++ b/packages/frieeren-components/src/components/Toast/ToastProvider.tsx
@@ -1,7 +1,7 @@
 import { Toaster } from "./Toast";
 import { createPortal } from "react-dom";
 import { useIsMounted } from "@/hooks/useIsMounted";
-import { createContext, ReactNode, useState, useCallback, useMemo } from "react";
+import { createContext, ReactNode, useState, useCallback, useMemo, useEffect } from "react";
 import { ToastContextValue, ToastOptions, ToastProviderProps, ToastType } from "./Toast.type";
 
 const defaultToastValue: ToastOptions = {
@@ -22,10 +22,23 @@ export const ToastContext = createContext<ToastContextValue>({
 
 const ToastPortal = ({ children }: { children: ReactNode }) => {
   const isMounted = useIsMounted();
-  const node = document.getElementById("toast-portal") as Element;
+  const [portalNode, setPortalNode] = useState<Element | null>(null);
 
-  if (!isMounted) return null;
-  return createPortal(children, node);
+  useEffect(() => {
+    let node = document.getElementById("toast-portal");
+
+    if (!node) {
+      node = document.createElement("div");
+      node.id = "toast-portal";
+      document.body.appendChild(node);
+    }
+
+    setPortalNode(node);
+  }, []);
+
+  if (!isMounted || !portalNode) return null;
+
+  return createPortal(children, portalNode);
 };
 
 export const ToastProvider = ({ options, children }: ToastProviderProps) => {


### PR DESCRIPTION
## 📝 PR 설명
Toast Component의 사용성을 개선합니다.

관련 이슈의 1번째 부분의 수정 내용입니다.

기존 사용시에는 Toast를 사용하기위해 아래와 같이 tag를 직접 넣어야하는 수고가 있습니다.
```tsx
<div id="toast-portal"></div>
```

이에 대한 수정으로, ToastPortal 생성 단계에서 `toast-portal` id를 찾아 없다면 동적으로 tag를 넣어주는 방향으로 수정을 하였습니다.
<!-- PR 설명 -->

## 관련된 이슈 넘버
- #15 
<!-- close #1 -->
close #15 
## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC
- version up: `1.0.5` -> `1.0.6`
<!-- Screenshot, References 기재 -->
