### PR TITLE
[Feat/#21] cannot find module '@team-frieren/components/styles' or its corresponding type declarations.ts

### DIFF
--- a/packages/frieeren-components/package.json
+++ b/packages/frieeren-components/package.json
@@ -90,6 +90,6 @@
       "import": "./dist/client.js",
       "types": "./dist/client.d.ts"
     },
-    "./styles": "./dist/index.css"
+    "./styles.css": "./dist/index.css"
   }
 }


### PR DESCRIPTION
## 📝 PR 설명
TypeScript 컴파일 에러 해결을 위해 style.css 파일을 모듈로 내보내도록 수정하였습니다.

<!-- PR 설명 -->

## 관련된 이슈 넘버

<!-- close #1 -->

## ✅ 작업 목록
- `@team-frieren/components/styles` 모듈 타입 선언 누락 문제 해결
<!-- 이슈 작업한 내용 -->

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the export path for CSS styles in the package configuration to improve clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->