### PR TITLE
[Feat/#27] 수동배포를 할 수 있도록 workflow 변경

### DIFF
--- a/.github/workflows/frieeren-component-CD.yml
+++ b/.github/workflows/frieeren-component-CD.yml
@@ -3,6 +3,15 @@ env:
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 on:
   workflow_dispatch:
+    inputs:
+      version-type:
+        description: 'Version update type'
+        required: true
+        type: choice
+        options:
+          - patch # 0.0.1 -> 0.0.2
+          - minor # 0.0.1 -> 0.1.0
+          - major # 0.0.1 -> 1.0.0
   push:
     branches:
       - main
@@ -10,9 +19,15 @@ on:
       - packages/frieeren-components/**
 permissions:
   contents: write
+env:
+  PROJECT_PATH: packages/frieeren-components
+  BOT_GITHUB_ACTOR: frieeren[bot]
+  BOT_GITHUB_EMAIL: frieeren2@gmail.com
+
 jobs:
   Deploy:
     runs-on: ubuntu-latest
+    if: "!(github.event_name == 'push' && github.actor == 'frieeren[bot]')"
     steps:
       - uses: actions/checkout@v2
 
@@ -50,11 +65,17 @@ jobs:
 
       - name: Increment version
         run: |
-          git config --local user.email "frieeren[bot]@users.noreply.github.com"
-          git config --local user.name "frieeren[bot]"
-          pnpm run publish-version:frieeren-components
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            VERSION_TYPE="${{ inputs.version-type }}"
+          else
+            VERSION_TYPE="patch"
+          fi
+
+          git config --local user.email "${{ env.BOT_GITHUB_EMAIL }}"
+          git config --local user.name "${{ env.BOT_GITHUB_ACTOR }}"
+          pnpm version $VERSION_TYPE --filter ${{ env.PROJECT_PATH }}
           git add .
-          git commit -m "chore(frieeren-components): update version"
+          git commit -m "chore(frieeren-components): update version to $VERSION_TYPE"
 
       - name: Push changes
         uses: ad-m/github-push-action@master
@@ -64,8 +85,8 @@ jobs:
 
       - name: Configure npm
         run: |
-          cat << EOF > "packages/frieeren-components/.npmrc"
-            email=frieeren2@gmail.com
+          cat << EOF > "${{ env.PROJECT_PATH }}/.npmrc"
+            email="${{ env.BOT_GITHUB_EMAIL }}"
             //registry.npmjs.org/:_authToken=$NPM_TOKEN 
           EOF
         env:


### PR DESCRIPTION
## 📝 PR 설명
수동배포 시 의도하지 않은 patch 버전 자동 증가 문제를 해결하기 위해 `@team-frieeren/components` CD 워크플로우를 개선했습니다.
<!-- PR 설명 -->

## 관련된 이슈 넘버
close #27 
<!-- close #1 -->

## ✅ 작업 목록
- Manual 업데이트 추가(workflow_dispatch)
  - GitHub Actions UI에서 workflow_dispatch를 통해 수동으로 배포 실행 가능합니다.
  - patch(0.0.1 -> 0.0.2), minor(0.0.1 -> 0.1.0), major(0.0.1 -> 1.0.0) 옵션을 활용가능합니다(default: patch)
- 무한 루프 방지
  - 봇이 생성한 업데이트의 경우 체크하여 동작하지 않도록 합니다. 
<!-- 이슈 작업한 내용 -->

## 📚 논의사항
- 현재 봇 이름으로 봇의 존재를 frieeren[bot]으로 판단하고 있느데요. 다른 방식에 대해 의견이 있으시다면 피드백부탁드립니다
- Push 이벤트 시 자동으로 patch 버전을 증가시키는 것이 적절한지 검토 필요할 것 같습니다
  - 코드 변경 없이 단순히 빌드/배포만 수행하는 옵션도 고려 가능할 것 같습니다.
<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->
