### PR TITLE
[Feat/#28] peerDependencies react19 지원

### DIFF
--- a/packages/frieeren-components/package.json
+++ b/packages/frieeren-components/package.json
@@ -64,8 +64,8 @@
     "vite-plugin-svgr": "^4.3.0"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.1",


### PR DESCRIPTION
## 📝 PR 설명
React 19 stable 버전 출시에 따라 기존 ^18.0.0 단일 버전 범위에서 ^18.0.0 || ^19.0.0로 확장하여 React 18과 React 19 모두를 지원
<!-- PR 설명 -->

## 관련된 이슈 넘버
close #28 
<!-- close #1 -->

## ✅ 작업 목록
- packages/frieeren-components/package.json의 peerDependencies 수정
  - React 버전 범위를 ^18.0.0에서 ^18.0.0 || ^19.0.0로 변경
  - React-DOM 버전 범위를 ^18.0.0에서 ^18.0.0 || ^19.0.0로 변경
<!-- 이슈 작업한 내용 -->

## 📚 논의사항
- React 19의 변경점이 컴포넌트 라이브러리에 주는 사이드이펙트는 별도로 검토가 필요할 수 있습니다.
- 향후 v20+ major 출시 시에도 동일한 방식으로 지원 범위를 확장하고자 합니다.
<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC
- https://react.dev/blog/2024/12/05/react-19
- https://docs.npmjs.com/cli/v6/using-npm/semver
<!-- Screenshot, References 기재 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated peer dependency requirements to support both React 18 and React 19.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->