### PR TITLE
[Feat/#32] pnpm install --frozen-lockfile 실행 시 lockfile 동기화 에러

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,10 +151,10 @@ importers:
         specifier: ^1.1.3
         version: 1.1.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
-        specifier: ^18.0.0
+        specifier: ^18.0.0 || ^19.0.0
         version: 18.3.1
       react-dom:
-        specifier: ^18.0.0
+        specifier: ^18.0.0 || ^19.0.0
         version: 18.3.1(react@18.3.1)
       sass:
         specifier: ^1.80.4


### PR DESCRIPTION
## 📝 PR 설명
packages/frieeren-components/package.json의 React 버전 변경사항과 동기화되지 않아 CI/CD에서 --frozen-lockfile 옵션으로 설치 시 실패하는 문제를 해결했습니다.

- #30 에서 변경한 peerDependencies으로 lockfile 업데이트가 필요하여 에러가 일어났습니다.
```yaml
      react:
        specifier: ^18.0.0 || ^19.0.0
        version: 18.3.1
      react-dom:
        specifier: ^18.0.0 || ^19.0.0
        version: 18.3.1(react@18.3.1)
```

<!-- PR 설명 -->

## 관련된 이슈 넘버
close #32 
<!-- close #1 -->

## ✅ 작업 목록
-  pnpm-lock.yaml 파일 업데이트(pnpm install --no-frozen-lockfile)
<!-- 이슈 작업한 내용 -->

## 📚 논의사항
@widse 
- 향후 peerDependencies 변경 시 lockfile 업데이트를 놓치지 않도록 하는 방안을 위해 CI 작업을 추가하는 것을 제안드립니다.
<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->
