### PR TITLE
[Feat/#35] NPM 패키지 배포 실패 - E404 인증 문제

### DIFF
--- a/.github/workflows/frieeren-component-CD.yml
+++ b/.github/workflows/frieeren-component-CD.yml
@@ -82,7 +82,7 @@ jobs:
           if [ "$VERSION_TYPE" == "prerelease" ]; then
             pnpm version prerelease --preid="alpha.${COMMIT_SHORT}" --no-git-tag-version
           else
-            pnpm version "$VERSION_TYPE" --no-git-tag-version
+            pnpm version "$VERSION_TYPE"
           fi
 
       - name: Push changes

--- a/.github/workflows/frieeren-component-CD.yml
+++ b/.github/workflows/frieeren-component-CD.yml
@@ -79,13 +79,14 @@ jobs:
           git config --local user.name "${{ env.BOT_GITHUB_ACTOR }}"
 
           COMMIT_SHORT=$(git rev-parse --short HEAD)
-          if [ "${{ VERSION_TYPE }}" == "prerelease" ]; then
+          if [ "$VERSION_TYPE" == "prerelease" ]; then
             pnpm version prerelease --preid="alpha.${COMMIT_SHORT}" --no-git-tag-version
           else
-            pnpm version "${{ VERSION_TYPE }}" --no-git-tag-version
+            pnpm version "$VERSION_TYPE" --no-git-tag-version
           fi
 
       - name: Push changes
+        if: inputs.version-type != 'prerelease'
         uses: ad-m/github-push-action@master
         with:
           branch: ${{ github.ref }}

--- a/.github/workflows/frieeren-component-CD.yml
+++ b/.github/workflows/frieeren-component-CD.yml
@@ -10,6 +10,7 @@ on:
           - patch # 0.0.1 -> 0.0.2
           - minor # 0.0.1 -> 0.1.0
           - major # 0.0.1 -> 1.0.0
+          - prerelease # 0.0.1 -> 0.0.2-alpha.1234567890
   push:
     branches:
       - main
@@ -34,6 +35,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
+        env:
+          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
@@ -73,8 +77,13 @@ jobs:
 
           git config --local user.email "${{ env.BOT_GITHUB_EMAIL }}"
           git config --local user.name "${{ env.BOT_GITHUB_ACTOR }}"
-          
-          pnpm version $VERSION_TYPE
+
+          COMMIT_SHORT=$(git rev-parse --short HEAD)
+          if [ "${{ VERSION_TYPE }}" == "prerelease" ]; then
+            pnpm version prerelease --preid="alpha.${COMMIT_SHORT}" --no-git-tag-version
+          else
+            pnpm version "${{ VERSION_TYPE }}" --no-git-tag-version
+          fi
 
       - name: Push changes
         uses: ad-m/github-push-action@master
@@ -83,12 +92,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tags: true
 
-      - name: Configure npm
-        run: |
-          cat << EOF > "${{ env.PROJECT_PATH }}/.npmrc"
-            email="${{ env.BOT_GITHUB_EMAIL }}"
-            //registry.npmjs.org/:_authToken=${{ env.NPM_TOKEN }}"
-          EOF
-
       - name: Deploy
-        run: pnpm run publish:frieeren-components
+        working-directory: ${{ env.PROJECT_PATH }}
+        run: pnpm run deploy


### PR DESCRIPTION
## 📝 PR 설명
GitHub Actions CD 워크플로우 수정 및 npm 배포 오류 해결하였습니다.
<!-- PR 설명 -->

## 관련된 이슈 넘버
close #35 
<!-- close #1 -->

## ✅ 작업 목록
- NPM 패키지 배포 시 인증 문제 해결을 위해 github action script 수정
  - npm 인증을 setup-node 단계에서 처리하도록 개선
- prerelease 버전 타입 추가 (patch/minor/major/prerelease)
<!-- 이슈 작업한 내용 -->

## 📚 논의사항
- 본 이슈를 진행하면서 테스트 환경을 고려하였는데요
  - act (로컬 GitHub Actions 테스트)
    - `act -W '.github/workflows/frieeren-component-CD.yml'`
    - .secret 파일 활용
  - pre-release 배포 테스트 적절한지 검토 필요합니다.(https://github.com/Frieeren/design-system/pull/29#issuecomment-3088122388 에서 논의되었던 방식입니다.)
    - prerelease 버전 네이밍 규칙 (`alpha.{commit_hash}`)로 alpha 버전을 추가할때마다 중복되지 않도록 최근 커밋 해시를 추가하였습니다.
      - [prerelease-tags](https://docs.npmjs.com/cli/v6/using-npm/semver#prerelease-tags)는 semver에서 명시적으로 지정되지않으면 release버전 기준으로 설치됩니다.
      - ^0.0.1 의존성이 있고 사용 가능한 버전이 0.0.9와 0.0.10_alpha_1일 때, 0.0.9가 설치됩니다.
    - prerelease는 추가 commit을 하지않고 배포만 진행합니다.
    - workflow_dispatch에 prerelease를 추가하였습니다.

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC
<img width="1600" height="356" alt="스크린샷 2025-07-19 오후 8 05 30" src="https://github.com/user-attachments/assets/1678373f-8de4-4962-b3a4-a1e4e719f76b" />

<!-- Screenshot, References 기재 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Chores**
  * Improved workflow to support prerelease versioning with custom identifiers.
  * Enhanced security and reliability by updating Node.js and npm authentication setup.
  * Updated deployment commands for more consistent deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->