### PR TITLE
[Bug] side effect 스타일 제거

### DIFF
--- a/packages/frieeren-components/src/components/Select/Select.scss
+++ b/packages/frieeren-components/src/components/Select/Select.scss
@@ -8,10 +8,6 @@
   --seed-palette-color-blue-1000: #0c4a6e;
 }
 
-button {
-  all: unset;
-}
-
 .select {
 }
 


### PR DESCRIPTION
## 📝 PR 설명
`<Select />` component button 전체 지정 style 제거
<!-- PR 설명 -->

## 관련된 이슈 넘버
- #72 
<!-- close #1 -->
close #72 
## ✅ 작업 목록
- button style 제거
<!-- 이슈 작업한 내용 -->

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Select 구성요소에서 버튼의 전역 스타일 초기화를 제거하여 기본 속성(포커스 링, 커서, 비활성 상태 등)이 정상적으로 유지됩니다. 예기치 않은 버튼 외형 및 상호작용 문제를 해소하고, 접근성 관련 시각적 피드백이 안정적으로 표시됩니다.
- Style
  - 불필요한 스타일 리셋 제거로 주변 UI에 대한 부작용을 줄이고, 디자인 시스템과의 일관성을 강화했습니다. 다른 화면의 버튼 스타일 오염 가능성도 낮아졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->